### PR TITLE
Add global lint config path support

### DIFF
--- a/extension/client/src/configuration.ts
+++ b/extension/client/src/configuration.ts
@@ -6,4 +6,5 @@ export function get<T>(prop: string) {
 }
 
 export const RULER_ENABLED_BY_DEFAULT = `rulerEnabledByDefault`;
+export const GLOBAL_LINT_CONFIG_PATH = `globalLintConfigPath`;
 export const projectFilesGlob = `**/*.{rpgle,RPGLE,sqlrpgle,SQLRPGLE,rpgleinc,RPGLEINC}`;

--- a/extension/client/src/linter.ts
+++ b/extension/client/src/linter.ts
@@ -1,6 +1,7 @@
 import path = require('path');
 import { commands, ExtensionContext, Uri, ViewColumn, window, workspace } from 'vscode';
 import {getInstance} from './base';
+import * as Configuration from './configuration';
 
 import {DEFAULT_SCHEMA} from "./schemas/linter"
 
@@ -117,8 +118,22 @@ export function initialise(context: ExtensionContext) {
 					} else {
 						window.showErrorMessage(`RPGLE linter config doesn't exist for this file. Would you like to create a default at ${configPath}?`, `Yes`, `No`).then
 							(async (value) => {
-								if (value === `Yes`) {
-									const jsonString = JSON.stringify(DEFAULT_SCHEMA, null, 2);
+                                                                if (value === `Yes`) {
+                                                                        let jsonString: string | undefined;
+
+                                                                        if (type === `member`) {
+                                                                                const globalPath = Configuration.get<string>(Configuration.GLOBAL_LINT_CONFIG_PATH);
+                                                                                if (globalPath) {
+                                                                                        try {
+                                                                                                const globalParts = connection.parserMemberPath(globalPath);
+                                                                                                jsonString = await content.downloadMemberContent(globalParts.library, globalParts.file, globalParts.name);
+                                                                                        } catch (e) {
+                                                                                                console.log(`Failed to load global lint config: ${e}`);
+                                                                                        }
+                                                                                }
+                                                                        }
+
+                                                                        if (!jsonString) jsonString = JSON.stringify(DEFAULT_SCHEMA, null, 2);
 
 									switch (type) {
 										case `member`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-rpgle",
-	"version": "0.31.1",
+	"version": "0.32.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-rpgle",
-			"version": "0.31.1",
+			"version": "0.32.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,13 +36,18 @@
 		"configuration": {
 			"title": "RPGLE language tools",
 			"properties": {
-				"vscode-rpgle.rulerEnabledByDefault": {
-					"type": "boolean",
-					"default": true,
-					"description": "Whether to show the fixed-format ruler by default."
-				}
-			}
-		},
+                                "vscode-rpgle.rulerEnabledByDefault": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Whether to show the fixed-format ruler by default."
+                                },
+                                "vscode-rpgle.globalLintConfigPath": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "QSYS object path to use as a template when creating RPGLINT.JSON inside a library."
+                                }
+                        }
+                },
 		"snippets": [
 			{
 				"path": "./schemas/rpgle.code-snippets",


### PR DESCRIPTION
## Summary
- introduce setting `vscode-rpgle.globalLintConfigPath`
- expose constant `GLOBAL_LINT_CONFIG_PATH`
- copy global lint config into library before creating default config
- update lockfile version
