### PR TITLE
Add global lint config option

### DIFF
--- a/extension/client/src/extension.ts
+++ b/extension/client/src/extension.ts
@@ -37,14 +37,22 @@ export function activate(context: ExtensionContext) {
 
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
-	const serverOptions: ServerOptions = {
-		run: { module: serverModule, transport: TransportKind.ipc },
-		debug: {
-			module: serverModule,
-			transport: TransportKind.ipc,
-			options: debugOptions
-		}
-	};
+        const globalLintPath = workspace.getConfiguration('vscode-rpgle').get<string>('globalLintConfigPath');
+        const env = { ...process.env } as NodeJS.ProcessEnv;
+        if (globalLintPath) env.GLOBAL_LINT_CONFIG_PATH = globalLintPath;
+
+        const serverOptions: ServerOptions = {
+                run: {
+                        module: serverModule,
+                        transport: TransportKind.ipc,
+                        options: { env }
+                },
+                debug: {
+                        module: serverModule,
+                        transport: TransportKind.ipc,
+                        options: { ...debugOptions, env }
+                }
+        };
 
 	loadBase();
 

--- a/extension/client/src/linter.ts
+++ b/extension/client/src/linter.ts
@@ -47,8 +47,30 @@ export function initialise(context: ExtensionContext) {
 				}
 
 			} else if (instance && instance.getConnection()) {
-				const connection = instance.getConnection();
-				const content = instance.getContent();
+                        const connection = instance.getConnection();
+                        const content = instance.getContent();
+
+                        const globalPath = Configuration.get<string>(Configuration.GLOBAL_LINT_CONFIG_PATH);
+
+                        if (globalPath) {
+                                try {
+                                        const parts = connection.parserMemberPath(globalPath);
+                                        const existsRes = await connection.runCommand({
+                                                command: `CHKOBJ OBJ(${parts.library}/${parts.file}) OBJTYPE(*FILE) MBR(${parts.name})`,
+                                                noLibList: true
+                                        });
+
+                                        if (existsRes.code === 0) {
+                                                await commands.executeCommand(`code-for-ibmi.openEditable`, globalPath);
+                                        } else {
+                                                window.showErrorMessage(`Global lint config does not exist at ${globalPath}.`);
+                                        }
+                                } catch (e) {
+                                        console.log(e);
+                                        window.showErrorMessage(`Failed to open global lint configuration.`);
+                                }
+                                return;
+                        }
 
 				/** @type {"member"|"streamfile"} */
 				let type = `member`;

--- a/extension/server/src/providers/linter/index.ts
+++ b/extension/server/src/providers/linter/index.ts
@@ -101,14 +101,29 @@ enum ResolvedState {
 let boundLintConfig: {[workingUri: string]: {resolved: ResolvedState, uri: string}} = {};
 
 export async function getLintConfigUri(workingUri: string) {
-	const uri = URI.parse(workingUri);
-	let cleanString: string | undefined;
+        const uri = URI.parse(workingUri);
+        let cleanString: string | undefined;
 
-	const cached = boundLintConfig[workingUri];
+        const cached = boundLintConfig[workingUri];
 
-	if (cached) {
-		return cached.resolved === ResolvedState.Found ? cached.uri : undefined;
-	}
+        if (cached) {
+                return cached.resolved === ResolvedState.Found ? cached.uri : undefined;
+        }
+
+        if (uri.scheme === `member`) {
+                const globalPath = process.env.GLOBAL_LINT_CONFIG_PATH;
+                if (globalPath) {
+                        cleanString = URI.from({ scheme: `member`, path: globalPath }).toString();
+                        cleanString = await validateUri(cleanString, `member`);
+                        if (cleanString) {
+                                boundLintConfig[workingUri] = {
+                                        resolved: ResolvedState.Found,
+                                        uri: cleanString
+                                };
+                                return cleanString;
+                        }
+                }
+        }
 
 	switch (uri.scheme) {
 		case `member`:


### PR DESCRIPTION
## Summary
- pipe global lint config path to the language server
- allow opening global lint config directly instead of per-library file
- load global lint config in the server if configured